### PR TITLE
Add travis support, I hope

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: ruby
+rvm:
+- "2.1"
+- "2.2.6"
+- "2.3.3"
+- "2.4.0"
+- ruby-head
+- jruby-head
+sudo: false
+cache: bundler
+addons:
+  apt:
+    packages:
+      - libopenscap8-dev
+matrix:
+  allow_failures:
+  - rvm: ruby-head
+  - rvm: jruby-head
+  fast_finish: true

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in openscap.gemspec
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,23 @@
+PATH
+  remote: .
+  specs:
+    openscap (0.4.7)
+      ffi (>= 1.0.9)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ffi (1.9.18)
+    rake (12.0.0)
+
+PLATFORMS
+  ruby
+  x86_64-darwin-15
+
+DEPENDENCIES
+  bundler (>= 1.0.0)
+  openscap!
+  rake
+
+BUNDLED WITH
+   1.14.6

--- a/Rakefile
+++ b/Rakefile
@@ -2,8 +2,11 @@ require 'bundler'
 
 Bundler::GemHelper.install_tasks :name => 'openscap'
 
-task :test do
-  $LOAD_PATH.unshift('lib')
-  $LOAD_PATH.unshift('test')
-  Dir.glob('./test/**/*_test.rb') { |f| require f }
+require "rake/testtask"
+Rake::TestTask.new do |t|
+  t.libs << "test"
+  t.test_files = FileList["test/**/*_test.rb"]
+  t.verbose = true
 end
+
+task :default => ["test"]

--- a/openscap.gemspec
+++ b/openscap.gemspec
@@ -17,6 +17,7 @@ GEMSPEC = Gem::Specification.new do |gem|
   Currently it provides only subset of libopenscap functionality."
 
   gem.add_development_dependency 'bundler', '>=1.0.0'
+  gem.add_development_dependency 'rake'
   gem.add_runtime_dependency 'ffi', '>= 1.0.9'
 
   gem.files = Dir['{lib,test}/**/*'] + ['COPYING', 'README.md', 'Rakefile']


### PR DESCRIPTION
@isimluk I think I got this close to working on travis but I don't know if it's using the right versions of libopenscap:

Using the provided ubuntu repos, it's using
```
Setting up libopenscap1 (0.8.0-4build1) ...
Setting up libopenscap-dev (0.8.0-4build1) ...
```

It's failing with this though:

```
/home/travis/build/jrafanie/ruby-openscap/vendor/bundle/ruby/2.1.0/gems/ffi-1.9.18/lib/ffi/library.rb:275:in `attach_function': Function 'oscap_document_type_to_string' not found in [libopenscap.so] (FFI::NotFoundError)
	from /home/travis/build/jrafanie/ruby-openscap/lib/openscap/openscap.rb:41:in `<module:OpenSCAP>'
	from /home/travis/build/jrafanie/ruby-openscap/lib/openscap/openscap.rb:14:in `<top (required)>'
	from /home/travis/build/jrafanie/ruby-openscap/lib/openscap.rb:12:in `require'
	from /home/travis/build/jrafanie/ruby-openscap/lib/openscap.rb:12:in `<top (required)>'
	from /home/travis/build/jrafanie/ruby-openscap/test/ds/arf_test.rb:12:in `require'
	from /home/travis/build/jrafanie/ruby-openscap/test/ds/arf_test.rb:12:in `<top (required)>'
	from /home/travis/build/jrafanie/ruby-openscap/vendor/bundle/ruby/2.1.0/gems/rake-12.0.0/lib/rake/rake_test_loader.rb:15:in `require'
	from /home/travis/build/jrafanie/ruby-openscap/vendor/bundle/ruby/2.1.0/gems/rake-12.0.0/lib/rake/rake_test_loader.rb:15:in `block in <main>'
	from /home/travis/build/jrafanie/ruby-openscap/vendor/bundle/ruby/2.1.0/gems/rake-
```

Maybe you could figure this out?  Also, are you looking to have travis enabled on this repo?  😆 