### PR TITLE
adding ident support for getting CVE names and urls

### DIFF
--- a/lib/openscap/xccdf/ident.rb
+++ b/lib/openscap/xccdf/ident.rb
@@ -1,0 +1,37 @@
+#
+# Copyright (c) 2015--2016 Red Hat Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+
+module OpenSCAP
+  module Xccdf
+    class Ident 
+      def initialize(raw)
+        raise OpenSCAP::OpenSCAPError, "Cannot initialize #{self.class.name} with '#{raw}'" \
+          unless raw.is_a?(FFI::Pointer)
+        @raw = raw
+      end
+
+      def system
+        OpenSCAP.xccdf_ident_get_system(@raw)
+      end
+
+      def id
+        OpenSCAP.xccdf_ident_get_id(@raw)
+      end
+
+
+    end
+  end
+  attach_function :xccdf_ident_get_system, [:pointer], :string
+  attach_function :xccdf_ident_get_id, [:pointer], :string
+end
+
+
+

--- a/lib/openscap/xccdf/ident.rb
+++ b/lib/openscap/xccdf/ident.rb
@@ -11,7 +11,7 @@
 
 module OpenSCAP
   module Xccdf
-    class Ident 
+    class Ident
       def initialize(raw)
         raise OpenSCAP::OpenSCAPError, "Cannot initialize #{self.class.name} with '#{raw}'" \
           unless raw.is_a?(FFI::Pointer)

--- a/lib/openscap/xccdf/ident.rb
+++ b/lib/openscap/xccdf/ident.rb
@@ -25,13 +25,8 @@ module OpenSCAP
       def id
         OpenSCAP.xccdf_ident_get_id(@raw)
       end
-
-
     end
   end
   attach_function :xccdf_ident_get_system, [:pointer], :string
   attach_function :xccdf_ident_get_id, [:pointer], :string
 end
-
-
-

--- a/lib/openscap/xccdf/item.rb
+++ b/lib/openscap/xccdf/item.rb
@@ -64,6 +64,17 @@ module OpenSCAP
         rationale
       end
 
+      def idents
+        idenss = []
+        idenss_it = OpenSCAP.xccdf_rule_get_idents(@raw)        
+        while OpenSCAP.xccdf_ident_iterator_has_more idenss_it          
+          idens = OpenSCAP::Xccdf::Ident.new(OpenSCAP.xccdf_ident_iterator_next(idenss_it))
+          idenss << idens
+        end
+        OpenSCAP.xccdf_ident_iterator_free idenss_it
+        idenss
+      end
+
       def references
         refs = []
         refs_it = OpenSCAP.xccdf_item_get_references(@raw)
@@ -124,4 +135,9 @@ module OpenSCAP
   attach_function :oscap_reference_iterator_has_more, [:pointer], :bool
   attach_function :oscap_reference_iterator_next, [:pointer], :pointer
   attach_function :oscap_reference_iterator_free, [:pointer], :void
+
+  attach_function :xccdf_rule_get_idents, [:pointer], :pointer
+  attach_function :xccdf_ident_iterator_has_more, [:pointer], :bool
+  attach_function :xccdf_ident_iterator_next, [:pointer], :pointer
+  attach_function :xccdf_ident_iterator_free, [:pointer], :void
 end

--- a/lib/openscap/xccdf/item.rb
+++ b/lib/openscap/xccdf/item.rb
@@ -62,7 +62,7 @@ module OpenSCAP
         rationale = textlist.plaintext(prefered_lang)
         textlist.destroy
         rationale
-      end    
+      end
 
       def references
         refs = []

--- a/lib/openscap/xccdf/item.rb
+++ b/lib/openscap/xccdf/item.rb
@@ -62,18 +62,7 @@ module OpenSCAP
         rationale = textlist.plaintext(prefered_lang)
         textlist.destroy
         rationale
-      end
-
-      def idents
-        idenss = []
-        idenss_it = OpenSCAP.xccdf_rule_get_idents(@raw)        
-        while OpenSCAP.xccdf_ident_iterator_has_more idenss_it          
-          idens = OpenSCAP::Xccdf::Ident.new(OpenSCAP.xccdf_ident_iterator_next(idenss_it))
-          idenss << idens
-        end
-        OpenSCAP.xccdf_ident_iterator_free idenss_it
-        idenss
-      end
+      end    
 
       def references
         refs = []
@@ -135,9 +124,4 @@ module OpenSCAP
   attach_function :oscap_reference_iterator_has_more, [:pointer], :bool
   attach_function :oscap_reference_iterator_next, [:pointer], :pointer
   attach_function :oscap_reference_iterator_free, [:pointer], :void
-
-  attach_function :xccdf_rule_get_idents, [:pointer], :pointer
-  attach_function :xccdf_ident_iterator_has_more, [:pointer], :bool
-  attach_function :xccdf_ident_iterator_next, [:pointer], :pointer
-  attach_function :xccdf_ident_iterator_free, [:pointer], :void
 end

--- a/lib/openscap/xccdf/rule.rb
+++ b/lib/openscap/xccdf/rule.rb
@@ -38,6 +38,17 @@ module OpenSCAP
         OpenSCAP.xccdf_fix_iterator_free items_it
         fixes
       end
+
+      def idents
+        idenss = []
+        idenss_it = OpenSCAP.xccdf_rule_get_idents(@raw)
+        while OpenSCAP.xccdf_ident_iterator_has_more idenss_it
+          idens = OpenSCAP::Xccdf::Ident.new(OpenSCAP.xccdf_ident_iterator_next(idenss_it))
+          idenss << idens
+        end
+        OpenSCAP.xccdf_ident_iterator_free idenss_it
+        idenss
+      end
     end
   end
   XccdfSeverity = enum(
@@ -53,4 +64,9 @@ module OpenSCAP
   attach_function :xccdf_fix_iterator_has_more, [:pointer], :bool
   attach_function :xccdf_fix_iterator_next, [:pointer], :pointer
   attach_function :xccdf_fix_iterator_free, [:pointer], :void
+
+  attach_function :xccdf_rule_get_idents, [:pointer], :pointer
+  attach_function :xccdf_ident_iterator_has_more, [:pointer], :bool
+  attach_function :xccdf_ident_iterator_next, [:pointer], :pointer
+  attach_function :xccdf_ident_iterator_free, [:pointer], :void
 end

--- a/lib/openscap/xccdf/rule.rb
+++ b/lib/openscap/xccdf/rule.rb
@@ -12,6 +12,7 @@
 require 'openscap/exceptions'
 require 'openscap/xccdf/item'
 require 'openscap/xccdf/fix'
+require 'openscap/xccdf/ident'
 
 module OpenSCAP
   module Xccdf

--- a/test/xccdf/arf_test.rb
+++ b/test/xccdf/arf_test.rb
@@ -1,0 +1,53 @@
+#
+# Copyright (c) 2014--2016 Red Hat Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+
+require 'common/testcase'
+require 'openscap'
+require 'openscap/ds/sds'
+require 'openscap/source'
+require 'openscap/xccdf/benchmark'
+
+class TestArf < OpenSCAP::TestCase
+  def test_new_from_file
+    b = benchmark_from_arf_file
+    b.destroy
+  end
+
+  def test_idents
+    b = benchmark_from_arf_file
+    item = b.items['xccdf_com.redhat.rhsa_rule_oval-com.redhat.rhsa-def-20140675']
+    idents = item.idents
+    assert idents.size == 25
+  end
+
+  def test_ident_title_url
+    b = benchmark_from_arf_file
+    item = b.items['xccdf_com.redhat.rhsa_rule_oval-com.redhat.rhsa-def-20140678']
+    idents = item.idents
+    assert idents.size == 2
+    ident = idents[0]
+    expected_id = 'RHSA-2014-0678'
+    expected_system = 'https://rhn.redhat.com/errata'
+    assert_equal(expected_id, ident.id)
+    assert_equal(expected_system, ident.system)
+  end
+
+  private
+
+  def benchmark_from_arf_file
+    arf = OpenSCAP::DS::Arf.new('../data/arf.xml')
+    _test_results = arf.test_result
+    source_datastream = arf.report_request
+    bench_source = source_datastream.select_checklist!
+    benchmark = OpenSCAP::Xccdf::Benchmark.new(bench_source)
+    benchmark
+  end
+end


### PR DESCRIPTION
This PR gives you the ability to query idents from the arf report. In the arf report it is actually the idents that contain the CVE references not the "references" element as shown below. 

```
<Rule selected="true" id="xccdf_com.redhat.rhsa_rule_oval-com.redhat.rhsa-def-20140675" severity="high">
    <title>RHSA-2014:0675: java-1.7.0-openjdk security update (Critical)</title>
    <ident system="https://rhn.redhat.com/errata">RHSA-2014-0675</ident>
    <ident system="http://cve.mitre.org">CVE-2014-0429</ident>
    <ident system="http://cve.mitre.org">CVE-2014-0446</ident>
    ...
```