### PR TITLE
Fix schematron-version attribute in test datastreams

### DIFF
--- a/test/data/sds-complex.xml
+++ b/test/data/sds-complex.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ds:data-stream-collection xmlns:ds="http://scap.nist.gov/schema/scap/source/1.2" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:cat="urn:oasis:names:tc:entity:xmlns:xml:catalog" id="scap_org.open-scap_collection_from_xccdf_first-xccdf.xml" schematron-version="1.0">
+<ds:data-stream-collection xmlns:ds="http://scap.nist.gov/schema/scap/source/1.2" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:cat="urn:oasis:names:tc:entity:xmlns:xml:catalog" id="scap_org.open-scap_collection_from_xccdf_first-xccdf.xml" schematron-version="1.2">
   <!-- This is bit more complex Datastream. The purpose is to test that scanner is able to find
         * datastream-id scap_org.open-scap_datastream_tst2
         * xccdf-id scap_org.open-scap_cref_second-xccdf.xml2


### PR DESCRIPTION
OpenSCAP 1.3.1 won't play with us if we use schematron-version=1.0. Let's play
according new rules.

Addressing:
https://bugzilla.redhat.com/show_bug.cgi?id=1736618

This is equivalent of
https://github.com/OpenSCAP/openscap/commit/b967d10ca3af64539367c3c6280f6dbb9fc2fd64